### PR TITLE
Zwx  mindmap post get api import & roadMap title & read-only view

### DIFF
--- a/src/apis/RoadmapEditorApis.js
+++ b/src/apis/RoadmapEditorApis.js
@@ -1,21 +1,13 @@
 import { req } from '../apis/util';
 
-function stringFormat() {
-  if (arguments.length === 0) { return null; }
-  // eslint-disable-next-line prefer-rest-params
-  let str = arguments[0];
-  for (let i = 1; i < arguments.length; i += 1) {
-    const re = new RegExp(`\\{${i - 1}\\}`, 'gm');
-    // eslint-disable-next-line prefer-rest-params
-    str = str.replace(re, arguments[i]);
-  }
-  return str;
-}
 
-export const createRoadmap = (nodes, connections) => req('/api/road_maps/', 'POST', {},
-  { text: JSON.stringify({ nodes, connections }), user: 1 });
+export const createRoadmap = (roadmapTitle, nodes, connections) => req('/api/road_maps/', 'POST', {},
+  { text: JSON.stringify({ nodes, connections }), title: roadmapTitle, user: 1 });
 
-export const updateRoadmap = (id, nodes, connections) => req(stringFormat('/api/road_maps/{0}/', id), 'PUT', {},
-  { text: JSON.stringify({ nodes, connections }), user: 1 });
+export const updateRoadmap = (id, roadmapTitle, nodes, connections) => req(`/api/road_maps/${id}/`, 'PUT', {},
+  { text: JSON.stringify({ nodes, connections }), title: roadmapTitle });
 
-export const getRoadmap = id => req(stringFormat('/api/road_maps/{0}/', id), 'GET');
+export const getRoadmap = id => req(`/api/road_maps/${id}/`, 'GET');
+
+export const updateRoadmapTitle = (id, roadmapTitle) => req(`/api/road_maps/${id}/`, 'PATCH', {},
+  { title: roadmapTitle });

--- a/src/apis/RoadmapEditorApis.js
+++ b/src/apis/RoadmapEditorApis.js
@@ -1,0 +1,21 @@
+import { req } from '../apis/util';
+
+function stringFormat() {
+  if (arguments.length === 0) { return null; }
+  // eslint-disable-next-line prefer-rest-params
+  let str = arguments[0];
+  for (let i = 1; i < arguments.length; i += 1) {
+    const re = new RegExp(`\\{${i - 1}\\}`, 'gm');
+    // eslint-disable-next-line prefer-rest-params
+    str = str.replace(re, arguments[i]);
+  }
+  return str;
+}
+
+export const createRoadmap = (nodes, connections) => req('/api/road_maps/', 'POST', {},
+  { text: JSON.stringify({ nodes, connections }), user: 1 });
+
+export const updateRoadmap = (id, nodes, connections) => req(stringFormat('/api/road_maps/{0}/', id), 'PUT', {},
+  { text: JSON.stringify({ nodes, connections }), user: 1 });
+
+export const getRoadmap = id => req(stringFormat('/api/road_maps/{0}/', id), 'GET');

--- a/src/components/LoadRoadmapForm.vue
+++ b/src/components/LoadRoadmapForm.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <MenuItem name="load-roadmap" @click.native="handleClkLoadRoadmap" ref="MenuItem">
+      Load Roadmap
+    </MenuItem>
+    <Modal
+      v-model="loadRoadmapFormModal"
+      title="Load Roadmap"
+      @on-ok="ok"
+      @on-cancel="cancel">
+      <p>Roadmap Id</p>
+      <Input v-model="roadmapInfo.roadmapId" placeholder="Enter Roadmap Id" style="width: 300px" />
+    </Modal>
+  </div>
+</template>
+<script>
+export default {
+  name: 'LoadRoadmapForm',
+  data() {
+    return {
+      loadRoadmapFormModal: false,
+      roadmapInfo: {
+        roadmapId: '',
+      },
+    };
+  },
+  methods: {
+    ok() {
+      this.$Notice.success({ title: 'RoadmapForm submitted' });
+      this.$emit('roadmap-form-loaded', this.roadmapInfo);
+    },
+    cancel() {
+      //  this.$Message.info('Clicked cancel');
+    },
+    handleClkLoadRoadmap() {
+      this.loadRoadmapFormModal = true;
+      this.$Message.info('handleClk');
+    },
+  },
+};
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -14,6 +14,11 @@ const routes = [
     name: 'Editor',
     component: () => import(/* webpackChunkName: "about" */ '../views/RoadmapEditorView.vue'),
   },
+  {
+    path: '/reader',
+    name: 'Reader',
+    component: () => import(/* webpackChunkName: "about" */ '../views/RoadmapReaderView.vue'),
+  },
 ];
 
 const router = new VueRouter({

--- a/src/views/RoadmapEditorView.vue
+++ b/src/views/RoadmapEditorView.vue
@@ -79,6 +79,15 @@
             :node-name-list="nodeNameList"
             :comment-list="commentList">
           </DelCommentForm>
+          <MenuItem name="save-roadmap" @click.native="handleClkSaveRoadmap">
+            Save Roadmap
+          </MenuItem>
+          <MenuItem name="load-roadmap" @click.native="handleClkLoadRoadmap">
+            Load Roadmap
+          </MenuItem>
+          <MenuItem name="create-roadmap" @click.native="handleClkCreateRoadmap">
+            create Roadmap
+          </MenuItem>
         </Submenu>
       </Menu>
     </Sider>
@@ -97,6 +106,7 @@ import DelCommentForm from '../components/DelCommentForm';
 import FileItem from '../components/FileItem';
 import { req } from '../apis/util';
 import errPush from '../components/ErrPush';
+import { createRoadmap, updateRoadmap, getRoadmap } from '../apis/RoadmapEditorApis';
 
 Vue.prototype._ = _;
 
@@ -238,6 +248,29 @@ export default {
     },
     handleSideMenuSelect(itemName) {
       this.SideMenuActiveItem = itemName;
+    },
+    handleClkSaveRoadmap() {
+      updateRoadmap(2, this.nodes, this.connections).then(() => {
+        this.$Notice.success({ title: 'Roadmap saved' });
+      }).catch(() => {
+        errPush(this, '4000', true);
+      });
+    },
+    handleClkLoadRoadmap() {
+      getRoadmap(2).then((res) => {
+        this.nodes = JSON.parse(res.data.text).nodes;
+        this.connections = JSON.parse(res.data.text).connections;
+        this.repaintMindMap();
+      }).catch(() => {
+        errPush(this, '4000', true);
+      });
+    },
+    handleClkCreateRoadmap() {
+      createRoadmap(this.nodes, this.connections).then(() => {
+        this.$Notice.success({ title: 'Roadmap created' });
+      }).catch(() => {
+        errPush(this, '4000', true);
+      });
     },
   },
 };

--- a/src/views/RoadmapReaderView.vue
+++ b/src/views/RoadmapReaderView.vue
@@ -1,0 +1,83 @@
+<template>
+  <Layout>
+    <Content :style="{minHeight: '280px', background: '#fff'}">
+      <div  id="roadmap-title">
+        {{roadMapTitle}}
+      </div>
+      <mindmap
+        :nodes="nodes"
+        :connections="connections"
+        :editable="true"
+        :key="repaint"
+      />
+    </Content>
+    <Sider hide-trigger :style="{background: '#fff'}">
+      <Button type="success" @click="handleClkEdit" id="b-ed">Edit</Button>
+    </Sider>
+  </Layout>
+</template>
+
+<script>
+import _ from 'lodash';
+import Vue from 'vue';
+import errPush from '../components/ErrPush';
+import { getRoadmap } from '../apis/RoadmapEditorApis';
+
+Vue.prototype._ = _;
+
+export default {
+  name: 'RoadmapEditor',
+  components: {
+  },
+  data() {
+    return {
+      roadMapId: -1,
+      roadMapTitle: 'roadMapTitleDefalt',
+      repaint: 1,
+      nodes: [
+      ],
+      connections: [
+      ],
+    };
+  },
+  computed: {
+  },
+  mounted() {
+    this.roadMapId = this.$route.query.selected;
+    getRoadmap(this.roadMapId).then((res) => {
+      this.nodes = JSON.parse(res.data.text).nodes;
+      this.connections = JSON.parse(res.data.text).connections;
+      this.roadMapTitle = res.data.title;
+      this.repaintMindMap();
+      this.$Notice.success({ title: `Roadmap loaded, id: ${this.roadMapId}` });
+    }).catch(() => {
+      errPush(this, '4000', true);
+    });
+  },
+  methods: {
+    handleClkEdit() {
+      this.$router.push({
+        path: '/editor',
+        query: { selected: this.roadMapId },
+      });
+    },
+    repaintMindMap() {
+      this.repaint += 1;
+    },
+  },
+};
+</script>
+
+<style scoped>
+  #roadmap-title{
+    text-align:center;
+    font-size: 24px;
+    padding: 12px;
+  }
+  #b-ed{
+    width: 120px;
+    margin-bottom: 20px;
+    margin-left: 40px;
+    margin-right: 40px;
+  }
+</style>


### PR DESCRIPTION
添加三个功能键
- save: 第一次打开页面curId = -1, save 等价于 create; curId不等于-1时，将当前编辑器内容存入后端curId的roadmap
- load: 输入一个id，load roadmap with given id;
- create: 将当前编辑器内容创建新的roadmap存入后端，改变curId为返回的新roadmap id;

- fixbug: cannot directly send `this.nodes` and `this.connections` to backend which contain extra data and cause wrong behavior when loaded the next time; use `this.simpleNodes` and `this.simpleConnections` instead.
close #33 
close #34 
close #42 
close #43 
![image](https://user-images.githubusercontent.com/34435428/79829782-94264f00-83d6-11ea-896c-1c57ea3fab1c.png)
![image](https://user-images.githubusercontent.com/34435428/79829809-a3a59800-83d6-11ea-87c8-cdb065dc5e02.png)
