### PR TITLE
Zwx  fixbug editor view select 1 unenable readonly

### DIFF
--- a/src/apis/RoadmapEditorApis.js
+++ b/src/apis/RoadmapEditorApis.js
@@ -2,7 +2,7 @@ import { req } from '../apis/util';
 
 
 export const createRoadmap = (roadmapTitle, nodes, connections, description) => req('/api/road_maps/', 'POST', {},
-  { text: JSON.stringify({ nodes, connections }), title: roadmapTitle, user: 1, description });
+  { text: JSON.stringify({ nodes, connections }), title: roadmapTitle, description });
 
 export const updateRoadmap = (id, roadmapTitle, nodes, connections, description) => req(`/api/road_maps/${id}/`, 'PUT', {},
   { text: JSON.stringify({ nodes, connections }), title: roadmapTitle, description });

--- a/src/apis/util.js
+++ b/src/apis/util.js
@@ -17,15 +17,15 @@ instanceNoAuth.interceptors.response.use(
       // code: 错误状态码， response：错误响应信息，error：原始错误信息
       switch (error.response.status) {
         case 400:
-          return Promise.reject({ code: 400, response: error.response, error }); // 客户端请求有语法错误
+          return Promise.reject({ code: 4000, response: error.response, error }); // 客户端请求有语法错误
         case 401:
-          return Promise.reject({ code: 401, response: error.response, error }); // 请求未经授权
+          return Promise.reject({ code: 4010, response: error.response, error }); // 请求未经授权
         case 404:
-          return Promise.reject({ code: 404, response: error.response, error }); // 页面未找到
+          return Promise.reject({ code: 4040, response: error.response, error }); // 页面未找到
         case 403:
-          return Promise.reject({ code: 403, response: error.response, error }); // Bad Gateway
+          return Promise.reject({ code: 4030, response: error.response, error }); // Bad Gateway
         case 500:
-          return Promise.reject({ code: 500, response: error.response, error }); // Server Error
+          return Promise.reject({ code: 5000, response: error.response, error }); // Server Error
         default:
           return Promise.reject({ code: -1, response: error.response, error }); // 不常见错误
       }
@@ -59,19 +59,19 @@ instanceAuth.interceptors.response.use(
       // code: 错误状态码， response：错误响应信息，error：原始错误信息
       switch (error.response.status) {
         case 400:
-          return Promise.reject({ code: 400, response: error.response, error }); // 客户端请求有语法错误
+          return Promise.reject({ code: 4000, response: error.response, error }); // 客户端请求有语法错误
         case 401: // 请求未经授权
         {
           store.commit('pushAuthToken', '');
           router.push({ name: 'Login' });
-          return Promise.reject({ code: 401, response: error.response, error });
+          return Promise.reject({ code: 4010, response: error.response, error });
         }
         case 404:
-          return Promise.reject({ code: 404, response: error.response, error }); // 页面未找到
+          return Promise.reject({ code: 4040, response: error.response, error }); // 页面未找到
         case 403:
-          return Promise.reject({ code: 403, response: error.response, error }); // Bad Gateway
+          return Promise.reject({ code: 4030, response: error.response, error }); // Bad Gateway
         case 500:
-          return Promise.reject({ code: 500, response: error.response, error }); // Server Error
+          return Promise.reject({ code: 5000, response: error.response, error }); // Server Error
         default:
           return Promise.reject({ code: -1, response: error.response, error }); // 不常见错误
       }

--- a/src/components/ErrPush.js
+++ b/src/components/ErrPush.js
@@ -6,6 +6,7 @@
 * */
 
 export default function pushError(obj, errCode, useModal = false, errTitle = '', errContent = '') {
+  window.console.warn('Deprecated method. Please use pushErr');
   let title = '';
   let content = '';
   if (errTitle === '' && errContent === '') {
@@ -63,3 +64,80 @@ export default function pushError(obj, errCode, useModal = false, errTitle = '',
     });
   }
 }
+
+export const pushErr = (obj, err, useModal = false, errTitle = '', errContent = '', modalType = 'error') => {
+  let title = '';
+  let content = '';
+  let errCode = '';
+  if (typeof err === 'string') {
+    errCode = err;
+  } else {
+    errCode = String(err.code);
+  }
+  if (errTitle === '' && errContent === '') {
+    if (errCode === '0001') {
+      title = 'DEBUG ERROR ';
+      content = '调试用错误';
+    } else if (errCode === '0010') {
+      title = 'Unfinished Exception';
+      content = '未实现的方法或接口';
+    } else if (errCode === '1000') {
+      title = 'Runtime Exception';
+      content = '运行时错误';
+    } else if (errCode === '1010') {
+      title = 'Undefined Object';
+      content = '访问未定义对象';
+    } else if (errCode === '4000') {
+      title = 'Unclassified Network Exception';
+      content = '无法分类的网络错误';
+    } else if (errCode === '4030') {
+      title = 'Permission Denied';
+      content = '没有权限';
+    } else if (errCode === '4040') {
+      title = 'Resources NOT Exist Exception';
+      content = '访问或查询不存在的资源';
+    } else if (errCode === '4010') {
+      title = 'Unauthorized Exception';
+      content = '请先登陆';
+      // eslint-disable-next-line no-param-reassign
+      modalType = 'info';
+    } else if (errCode === '5010') {
+      title = 'Incomplete Input';
+      content = '用户名/密码输入不完整';
+    } else if (errCode === '5020') {
+      title = 'Login Fail';
+      content = '登陆失败';
+    } else {
+      return;
+    }
+  } else {
+    title = errTitle;
+    content = errContent;
+  }
+  window.console.error('[ERROR] ', title, ': ', content);
+
+  if (useModal) {
+    if (modalType === 'info') {
+      obj.$Modal.info({
+        title,
+        content,
+        okText: '知道了~',
+      });
+    } else {
+      obj.$Modal.error({
+        title,
+        content,
+        okText: '知道了~',
+      });
+    }
+  } else {
+    title += ': ';
+    title += content;
+    obj.$Message.error({
+      background: true,
+      content: title,
+      duration: 5,
+      closable: true,
+    });
+  }
+};

--- a/src/components/MindTable.vue
+++ b/src/components/MindTable.vue
@@ -4,6 +4,7 @@
       v-bind:drawer="drawer"
       v-bind:index="index"
       v-bind:drawerFormData="drawerFormData"
+      v-bind:articles="tableData"
       @cancelDrawer="cancelDrawer"
       @submitDrawer="submitDrawer"
     >
@@ -23,7 +24,7 @@
 </template>
 <script>
 import _ from 'lodash';
-import errPush from '../components/ErrPush';
+import { pushErr } from '../components/ErrPush';
 import ItemEditor from './TableItemEditor';
 import { deleteMTdata, createMTdata, changeMTdata } from '../apis/MindTableEditorApis';
 
@@ -173,8 +174,8 @@ export default {
             this.$Notice.success('MT data created');
             this.$emit('reloadData');
           })
-          .catch(() => {
-            errPush(this, '4000', true);
+          .catch((err) => {
+            pushErr(this, err, true);
           });
       } else {
         // (id, title, author, url, note, ref)
@@ -183,8 +184,8 @@ export default {
             this.$Notice.success('MT data change');
             this.$emit('reloadData');
           })
-          .catch(() => {
-            errPush(this, '4000', true);
+          .catch((err) => {
+            pushErr(this, err, true);
           });
       }
       this.drawer = false;

--- a/src/components/MindTable.vue
+++ b/src/components/MindTable.vue
@@ -171,7 +171,7 @@ export default {
           drawerFormData.note,
           drawerFormData.article_references)
           .then(() => {
-            this.$Notice.success('MT data created');
+            // this.$Message.info('MT data created');
             this.$emit('reloadData');
           })
           .catch((err) => {
@@ -181,7 +181,7 @@ export default {
         // (id, title, author, url, note, ref)
         changeMTdata(drawerFormData)
           .then(() => {
-            this.$Notice.success('MT data change');
+            // this.$Message.info('MT data change');
             this.$emit('reloadData');
           })
           .catch((err) => {

--- a/src/components/RoadmapTable.vue
+++ b/src/components/RoadmapTable.vue
@@ -21,7 +21,7 @@
 import _ from 'lodash';
 import ItemEditor from './RoadItemEditor';
 import { req } from '../apis/util';
-import errPush from './ErrPush';
+import { pushErr } from '../components/ErrPush';
 import { delRoadmap } from '../apis/RoadmapEditorApis';
 
 export default {
@@ -119,8 +119,8 @@ export default {
     req('/api/road_maps/', 'GET').then((res) => {
       this.roadmaps = res.data;
       this.data = this.getData();
-    }).catch(() => {
-      errPush(this, '4000', true);
+    }).catch((err) => {
+      pushErr(this, err, true);
     });
   },
   methods: {
@@ -162,8 +162,8 @@ export default {
         this.data.splice(posInTable, 1);
         window.console.log('onDelete', index);
         this.$Message.info(`${res.data.id} Deleted`);
-      }).catch(() => {
-        errPush(this, '4000', true);
+      }).catch((err) => {
+        pushErr(this, err, true);
       });
     },
     cancelDrawer() {

--- a/src/components/TableItemEditor.vue
+++ b/src/components/TableItemEditor.vue
@@ -85,11 +85,14 @@
 </template>
 <script>
 import _ from 'lodash';
-import { req } from '../apis/util';
 
 export default {
   name: 'ItemEditor',
   props: {
+    articles: {
+      type: Array,
+      required: true,
+    },
     drawer: {
       type: Boolean,
     },
@@ -109,20 +112,14 @@ export default {
         paddingBottom: '53px',
         position: 'static',
       },
-      transferData: [],
     };
-  },
-  async mounted() {
-    const data = (await req('/api/articles', 'GET')).data;
-
-    // 'key' is required by iview transfer
-    this.transferData = _.map(data, atc => ({ key: atc.id, label: atc.title }));
-
-    // lazy loading this, just after all article data loaded
   },
   computed: {
     targetKeys() {
       return this.drawerFormData.article_references;
+    },
+    transferData() {
+      return _.map(this.articles, atc => ({ key: atc.id, label: atc.title }));
     },
   },
   methods: {

--- a/src/components/UserReportButton.vue
+++ b/src/components/UserReportButton.vue
@@ -28,6 +28,7 @@
 
 <script>
 import { createFeedBack } from '../apis/FeedBackApis';
+import { pushErr } from '../components/ErrPush';
 
 export default {
   name: 'UserReportButton',
@@ -43,8 +44,9 @@ export default {
     okModal() {
       createFeedBack(this.UserEmail, this.UserRating, this.UserSuggest).then(() => {
         this.$Message.info('感谢您的反馈，我们会努力改进 ~');
-      }).catch(() => {
-        this.$Message.error('网络错误');
+      }).catch((err) => {
+        pushErr(this, err, true);
+        // this.$Message.error('网络错误');
       });
 
       this.cancelModal();

--- a/src/views/ArticleTableView.vue
+++ b/src/views/ArticleTableView.vue
@@ -10,7 +10,7 @@
 <script>
 import MindTable from '../components/MindTable';
 import { req } from '../apis/util';
-import errPush from '../components/ErrPush';
+import { pushErr } from '../components/ErrPush';
 
 export default {
   name: 'ArticleTableView',
@@ -24,8 +24,8 @@ export default {
     reloadData() {
       req('/api/articles/', 'GET').then((res) => {
         this.articles = res.data;
-      }).catch(() => {
-        errPush(this, '4000', true);
+      }).catch((err) => {
+        pushErr(this, err, true);
       });
     },
   },

--- a/src/views/RoadmapEditorView.vue
+++ b/src/views/RoadmapEditorView.vue
@@ -70,7 +70,10 @@
       />
     </Content>
     <Sider hide-trigger :style="{background: '#fff'}">
-      <Button type="info" @click="handleClkReadOnly" id="b-ro">Read Only</Button>
+      <Button type="info" @click="handleClkReadOnly"
+              :disabled="roadMapId===-1" id="b-ro">
+        Read Only
+      </Button>
       <Menu active-name="1-2" theme="dark" width="auto" :open-names="['1']">
         <Submenu name="1">
           <template slot="title">

--- a/src/views/RoadmapEditorView.vue
+++ b/src/views/RoadmapEditorView.vue
@@ -130,7 +130,7 @@ import LoadRoadmapForm from '../components/LoadRoadmapForm';
 import EditRoadmapDescriptionForm from '../components/EditRoadmapDescriptionForm';
 import FileItem from '../components/FileItem';
 import { req } from '../apis/util';
-import errPush from '../components/ErrPush';
+import { pushErr } from '../components/ErrPush';
 import { createRoadmap, updateRoadmap, getRoadmap, updateRoadmapTitle, updateRoadmapDescription } from '../apis/RoadmapEditorApis';
 import Roadmap from '../components/roadmap/Roadmap';
 
@@ -269,12 +269,12 @@ export default {
             this.repaintMindMap();
             this.$Notice.success({ title: `Roadmap loaded, id: ${this.roadMapId}` });
           })
-          .catch(() => {
-            errPush(this, '4000', true);
+          .catch((err) => {
+            pushErr(this, err, true);
           });
       }
-    }).catch(() => {
-      errPush(this, '4000', true);
+    }).catch((err) => {
+      pushErr(this, err, true);
     });
   },
   methods: {
@@ -382,16 +382,16 @@ export default {
           .then((res) => {
             this.$Notice.success({ title: `Roadmap created, id: ${res.data.id}` });
             this.roadMapId = res.data.id;
-          }).catch(() => {
-            errPush(this, '4000', true);
+          }).catch((err) => {
+            pushErr(this, err, true);
           });
       } else {
         updateRoadmap(this.roadMapId, this.roadMapTitle, this.savedNodes, this.savedConnections,
           this.description)
           .then(() => {
             this.$Notice.success({ title: `Roadmap saved, id: ${this.roadMapId}` });
-          }).catch(() => {
-            errPush(this, '4000', true);
+          }).catch((err) => {
+            pushErr(this, err, true);
           });
       }
     },
@@ -403,16 +403,16 @@ export default {
         this.repaintMindMap();
         this.roadMapId = roadmapInfo.roadmapId;
         this.$Notice.success({ title: `Roadmap loaded, id: ${this.roadMapId}` });
-      }).catch(() => {
-        errPush(this, '4000', true);
+      }).catch((err) => {
+        pushErr(this, err, true);
       });
     },
     handleClkCreateRoadmap() {
       createRoadmap(this.roadMapTitle, this.savedNodes, this.savedConnections).then((res) => {
         this.$Notice.success({ title: `Roadmap created, id: ${res.data.id}` });
         this.roadMapId = res.data.id;
-      }).catch(() => {
-        errPush(this, '4000', true);
+      }).catch((err) => {
+        pushErr(this, err, true);
       });
     },
     handleClkEditTitle() {
@@ -426,8 +426,8 @@ export default {
       if (this.roadMapId !== -1) {
         updateRoadmapDescription(this.roadMapId, newDesc).then(() => {
           this.$Notice.success({ title: 'description sent' });
-        }).catch(() => {
-          errPush(this, '4000', true);
+        }).catch((err) => {
+          pushErr(this, err, true);
         });
       }
     },
@@ -435,8 +435,8 @@ export default {
       if (this.roadMapId !== -1) {
         updateRoadmapTitle(this.roadMapId, this.roadMapTitle).then(() => {
           this.$Notice.success({ title: 'Roadmap Title Updated' });
-        }).catch(() => {
-          errPush(this, '4000', true);
+        }).catch((err) => {
+          pushErr(this, err, true);
         });
       }
       this.titleEditable = false;

--- a/src/views/RoadmapReaderView.vue
+++ b/src/views/RoadmapReaderView.vue
@@ -26,7 +26,7 @@
 <script>
 import _ from 'lodash';
 import Vue from 'vue';
-import errPush from '../components/ErrPush';
+import { pushErr } from '../components/ErrPush';
 import { getRoadmap } from '../apis/RoadmapEditorApis';
 import { req } from '../apis/util';
 import Roadmap from '../components/roadmap/Roadmap';
@@ -62,8 +62,8 @@ export default {
       this.description = roadmapData.description;
       this.repaintMindMap();
       this.$Notice.success({ title: `Roadmap loaded, id: ${this.roadMapId}` });
-    } catch (e) {
-      errPush(this, '4000', true);
+    } catch (err) {
+      pushErr(this, err, true);
     }
   },
   computed: {

--- a/src/views/UserLoginView.vue
+++ b/src/views/UserLoginView.vue
@@ -21,7 +21,7 @@
 <script>
 
 import { reqNoAuth } from '../apis/util';
-import errPush from '../components/ErrPush';
+import { pushErr } from '../components/ErrPush';
 import store from '../vuex/index';
 import router from '../router';
 
@@ -36,7 +36,7 @@ export default {
   methods: {
     login() {
       if (!this.userName || !this.password) {
-        errPush(this, '5010');
+        pushErr(this, '5010');
       } else {
         const tempData = {
           username: this.userName,
@@ -56,9 +56,9 @@ export default {
     },
     handle_error(response) {
       if (response.code === 400) {
-        errPush(this, '5020');
+        pushErr(this, '5020');
       } else {
-        errPush(this, '0000', false, '网络错误', `${response.code}`);
+        pushErr(this, '0000', false, '网络错误', `${response.code}`);
       }
     },
   },


### PR DESCRIPTION
zwx: fixbug: editor view是-1的时候， 禁止跳转到reader

zwx: fix error modal, use pushErr instead of pushError; 把登陆错误变成info框;文献管理drawer用props不用req

zwx: 去掉路书post的userid字段