### PR TITLE
zwx: fixbug 后端的api分页引起的roadmap变化

### DIFF
--- a/src/components/RoadmapCardTable.vue
+++ b/src/components/RoadmapCardTable.vue
@@ -80,7 +80,7 @@
 <script>
 import _ from 'lodash';
 import ItemEditor from './RoadItemEditor';
-import { req } from '../apis/util';
+import { reqSingle } from '../apis/util';
 import { pushErr } from '../components/ErrPush';
 import { delRoadmap, postRoadmapShareLink } from '../apis/RoadmapEditorApis';
 
@@ -198,9 +198,10 @@ export default {
     };
   },
   mounted() {
-    req('/api/road_maps/', 'GET')
+    reqSingle('/api/road_maps/', 'GET', { page: 1 })
       .then((res) => {
-        this.roadmaps = res.data;
+        // window.console.log('roadmap card', res);
+        this.roadmaps = res.data.results;
         this.data = this.getData();
       })
       .catch((err) => {

--- a/src/components/RoadmapTable.vue
+++ b/src/components/RoadmapTable.vue
@@ -20,7 +20,7 @@
 <script>
 import _ from 'lodash';
 import ItemEditor from './RoadItemEditor';
-import { req } from '../apis/util';
+import { reqSingle } from '../apis/util';
 import { pushErr } from '../components/ErrPush';
 import { delRoadmap, postRoadmapShareLink } from '../apis/RoadmapEditorApis';
 
@@ -136,12 +136,14 @@ export default {
     };
   },
   mounted() {
-    req('/api/road_maps/', 'GET').then((res) => {
-      this.roadmaps = res.data;
-      this.data = this.getData();
-    }).catch((err) => {
-      pushErr(this, err, true);
-    });
+    reqSingle('/api/road_maps/', 'GET', { page: 1 })
+      .then((res) => {
+        // window.console.log('roadmap card', res);
+        this.roadmaps = res.data.results;
+        this.data = this.getData();
+      }).catch((err) => {
+        pushErr(this, err, true);
+      });
   },
   methods: {
     getData() {

--- a/src/views/RoadmapEditorView.vue
+++ b/src/views/RoadmapEditorView.vue
@@ -196,7 +196,7 @@ import ModifyCommentForm from '../components/ModifyCommentForm';
 import ModifyNodeForm from '../components/ModifyNodeForm';
 import FileItem from '../components/FileItem';
 import NoteMarkdown from '../components/NoteMarkdown';
-import { req } from '../apis/util';
+import { reqSingle } from '../apis/util';
 import { pushErr } from '../components/ErrPush';
 import {
   createRoadmap,
@@ -395,8 +395,8 @@ export default {
   },
   mounted() {
     // GET articles for l-sider
-    req('/api/articles/', 'GET').then((res1) => {
-      this.articles = res1.data;
+    reqSingle('/api/articles/', 'GET', { page: 1 }).then((res1) => {
+      this.articles = res1.data.results;
       // load roadMap if has query
       if ((typeof (this.$route.query.selected) !== 'undefined') &&
         (String(this.$route.query.selected) !== '-1')) {


### PR DESCRIPTION
暂时article和roadmap只取第一页，先让网站能跑起来
后续：
前端的路书要做分页
后端要提供得到全部articles的api
前端路书编辑器改回得到全部api

close #158 