### PR TITLE
Zwx  article alias

### DIFF
--- a/src/apis/MindTableEditorApis.js
+++ b/src/apis/MindTableEditorApis.js
@@ -14,3 +14,5 @@ export const changeMTdata = data => req(
 export const getAllNewPapers = () => req('/api/newpapers/', 'GET', {});
 
 export const getArticle = id => reqSingle(`/api/articles/${id}/`, 'GET');
+
+export const updateAlias = (id, alias) => reqSingle(`/api/articles/${id}/`, 'PATCH', { alias });

--- a/src/components/ModifyAliasForm.vue
+++ b/src/components/ModifyAliasForm.vue
@@ -1,0 +1,56 @@
+<template>
+  <div>
+    <MenuItem name="modify-alias" @click.native="handleClkModifyAlias"
+              ref="MenuItem" >
+      <div v-if="aliasInfoOld.using_alias">
+        修改别名
+        <Icon type="md-git-commit" />
+      </div>
+      <div v-else>
+        使用别名
+        <Icon type="md-git-commit" />
+      </div>
+    </MenuItem>
+    <Modal
+      v-model="aliasFormModal"
+      title="Modify Alias"
+      @on-ok="ok"
+      @on-cancel="cancel"
+      @keydown.native.stop>
+      <p>修改文献别名（将同步到文献管理中）</p>
+      <Input v-model="nodeInfo.alias" placeholder="Enter something..." style="width: 300px" />
+      <p>是否在改节点使用文献别名</p>
+      <Checkbox v-model="nodeInfo.using_alias">使用文献别名</Checkbox>
+    </Modal>
+  </div>
+</template>
+<script>
+export default {
+  name: 'AddNodeForm',
+  props: ['aliasInfoOld'],
+  data() {
+    return {
+      aliasFormModal: false,
+      nodeInfo: {
+        alias: this.aliasInfoOld.alias,
+        using_alias: this.aliasInfoOld.using_alias,
+      },
+    };
+  },
+  methods: {
+    ok() {
+      this.$Message.info('Alias modified');
+      this.$emit('alias-modified', this.nodeInfo);
+    },
+    cancel() {
+      //  this.$Message.info('Clicked cancel');
+    },
+    handleClkModifyAlias() {
+      this.aliasFormModal = true;
+      this.nodeInfo.alias = this.aliasInfoOld.alias;
+      this.nodeInfo.using_alias = this.aliasInfoOld.using_alias;
+      this.$Message.info('handleClk');
+    },
+  },
+};
+</script>

--- a/src/components/ModifyNodeForm.vue
+++ b/src/components/ModifyNodeForm.vue
@@ -40,6 +40,8 @@ export default {
     },
     handleClkModifyNode() {
       this.nodeFormModal = true;
+      this.nodeInfo.nodeName = this.nodeInfoOld.name;
+      this.nodeInfo.nodeUrl = this.nodeInfoOld.URI;
       this.$Message.info('handleClk');
     },
   },

--- a/src/components/roadmap/Roadmap.vue
+++ b/src/components/roadmap/Roadmap.vue
@@ -213,9 +213,8 @@ export default {
             onTick(conns, nodes, subnodes)
           ));
       }, 200);
-      window.console.log('wtf1', this.curNode);
+      window.console.log('roadmap curNode', this.curNode);
       if (this.curNode) {
-        window.console.log('wtf');
         nodes.attr('class', (n) => {
           if (n === this.curNode) {
             return `${n.category}-node-chosen article-node--editable`;

--- a/src/views/RoadmapEditorView.vue
+++ b/src/views/RoadmapEditorView.vue
@@ -895,8 +895,8 @@ export default {
             node.category_id = articleId;
             // eslint-disable-next-line no-param-reassign
             node.using_alias = node.using_alias || false;
-            // eslint-disable-next-line no-param-reassign
-            node.content = node.using_alias ? art.alias : art.title;
+            // eslint-disable-next-line no-param-reassign,no-nested-ternary
+            node.content = node.using_alias ? (art.alias === '' ? art.title : art.alias) : art.title;
           } else {
             // eslint-disable-next-line no-param-reassign
             node.category = 'mindmap';

--- a/src/views/RoadmapEditorView.vue
+++ b/src/views/RoadmapEditorView.vue
@@ -384,7 +384,7 @@ export default {
       });
       _.forEach(articleNodes, (ni) => {
         _.forEach(articleNodes, (nj) => {
-          if (_.includes(ni.article.article_references, nj.category_id)) {
+          if (_.includes(ni.article.article_references, nj.article.id)) {
             let curve = { x: 0, y: 0 };
             const tempConn = _.find(this.refCurves, nk =>
               (nk.curve && (ni.text === nk.source) && (nj.text === nk.target)));

--- a/src/views/RoadmapReaderView.vue
+++ b/src/views/RoadmapReaderView.vue
@@ -150,7 +150,7 @@ export default {
       });
       _.forEach(articleNodes, (ni) => {
         _.forEach(articleNodes, (nj) => {
-          if (_.includes(ni.article.article_references, nj.category_id)) {
+          if (_.includes(ni.article.article_references, nj.article.id)) {
             let curve = { x: 0, y: 0 };
             const tempConn = _.find(this.refCurves, nk =>
               (nk.curve && (ni.text === nk.source) && (nj.text === nk.target)));

--- a/src/views/RoadmapReaderView.vue
+++ b/src/views/RoadmapReaderView.vue
@@ -145,12 +145,12 @@ export default {
       let conn = [];
       let articleNodes = _.filter(this.nodes, node => (node.category === 'article'));
       articleNodes = _.map(articleNodes, (node) => {
-        const article = _.find(this.articles, atc => (atc.title === node.content));
+        const article = this.getArticleById(node.category_id);
         return { ...node, article };
       });
       _.forEach(articleNodes, (ni) => {
         _.forEach(articleNodes, (nj) => {
-          if (_.includes(ni.article.article_references, nj.article.id)) {
+          if (_.includes(ni.article.article_references, nj.category_id)) {
             let curve = { x: 0, y: 0 };
             const tempConn = _.find(this.refCurves, nk =>
               (nk.curve && (ni.text === nk.source) && (nj.text === nk.target)));
@@ -192,8 +192,8 @@ export default {
     },
     curNote() {
       if (!this.curNode || this.curNode.category !== 'article') return '';
-      if (this.getArticleByTitle(this.curNode.content).note) {
-        return this.getArticleByTitle(this.curNode.content).note;
+      if (this.getArticleById(this.curNode.category_id).note) {
+        return this.getArticleById(this.curNode.category_id).note;
       }
       return '';
     },
@@ -236,11 +236,13 @@ export default {
           const art = this.getArticleById(articleId);
           if (typeof art !== 'undefined') {
             // eslint-disable-next-line no-param-reassign
-            node.content = art.title;
-            // eslint-disable-next-line no-param-reassign
             node.URI = art.url;
             // eslint-disable-next-line no-param-reassign
             node.category_id = articleId;
+            // eslint-disable-next-line no-param-reassign
+            node.using_alias = node.using_alias || false;
+            // eslint-disable-next-line no-param-reassign,no-nested-ternary
+            node.content = node.using_alias ? (art.alias === '' ? art.title : art.alias) : art.title;
           } else {
             // eslint-disable-next-line no-param-reassign
             node.category = 'mindmap';
@@ -271,7 +273,9 @@ export default {
     toDisplayConnections(savedConnections) {
       return savedConnections;
     },
+    // @deprecated
     getArticleByTitle(title) {
+      window.console.warn('this function is deprecated, which cannot suport duplicated article name. Use getArticleById instead');
       return _(this.articles).find(art => art.title === title);
     },
     handleNodeClick(node) {
@@ -327,7 +331,7 @@ export default {
     jumpArticleNoteEdit() {
       this.$router.push({
         path: '/articleMde',
-        query: { selected: this.getArticleIdByTitle(this.curNode.content) },
+        query: { selected: this.curNode.category_id },
       });
     },
     handleCommentCommitted(com) {


### PR DESCRIPTION
- 路书编辑器引入别名alias
- 添加双击快捷键
- 修复双击node bug，双击后应该重新赋值表单数据
- 删掉了某些log信息
- 使用getArticleById替换了getArticleByTitle函数
- 路书阅览器引入别名alias
- 当别名为空时使用title
- 路书阅览器中不使用getArticleByTitle
close #184 