### PR TITLE
增加路书界面的用户偏好🍪，增加处理的浮窗显示

### DIFF
--- a/src/components/RoadmapCardTable.vue
+++ b/src/components/RoadmapCardTable.vue
@@ -41,11 +41,26 @@
         </ItemEditor>
     </div>
     <div v-else-if="this.viewStyle==='card'" style="margin-top: 20px;">
+      <div v-show="floatSeen" :style="floatPosition">
+        <img v-if="floatDataIndex>=0 && !data[floatDataIndex].isEmpty"
+             :src="data[floatDataIndex].thumbnail"
+             :style="floatImageSize"
+        >
+        <img v-else src="../assets/RoadmapDefault.png" :style="floatImageSize">
+      </div>
     <Row v-for="r in rows" v-bind:key="r" type="flex" justify="center" :gutter="20">
       <i-col v-for="c in cols" v-bind:key="c" span="6" align="center" >
         <!-- getIndex函数用于获取指定r和c后，路书在index中的索引。对于新建路书，getIndex会返回-1 -->
         <Card v-show="getIndex(r, c, cols) + 1 < data.length + 1"
               style="margin-bottom: 20px">
+          <!--右上角简易查看-->
+          <p slot="extra" v-if="!(r === 1 && c === 1)"
+             @mouseenter="mouseOnThumbnail(r, c, cols)"
+             @mouseleave="mouseLeaveThumbnail"
+             @mousemove="updateFloatXY">
+            <Icon type="ios-search"></Icon>
+            预览
+          </p>
           <!--新建路书部件-->
           <div class="card_content" v-if="r === 1 && c === 1">
             <p class="single_line">
@@ -64,9 +79,7 @@
             </h4>
 
             <!-- 缩略图或默认图加载 -->
-            <div class="card_img"
-                 @mouseenter="mouseOnThumbnail"
-                 @mouseleave="mouseLeaveThumbnail">
+            <div class="card_img">
               <img v-if="showThumbnail(r, c)"
                    :src="data[getIndex(r,c,cols)].thumbnail"
                    class="card_img"
@@ -132,6 +145,11 @@ export default {
       oriTags: [],
       cols: 3,
       viewStyle: 'card',
+      // float window
+      floatSeen: false,
+      floatPosition: { position: 'absolute', top: '20px', left: '20px', 'z-index': 2 },
+      floatDataIndex: -1,
+      floatImageSize: { width: '500px', background: 'white' },
       initialViewStyle: undefined,
       filtArticle: -1,
       // data: [],
@@ -462,11 +480,18 @@ export default {
       }
       store.commit('pushRoadMapTable', this.viewStyle);
     },
-    mouseOnThumbnail() {
-      window.console.info('Mouse enter.');
+    mouseOnThumbnail(r, c, cols) {
+      this.floatDataIndex = this.getIndex(r, c, cols);
+      window.console.info(`Mouse moved to ${this.floatDataIndex}`);
+      this.floatSeen = true;
     },
     mouseLeaveThumbnail() {
       window.console.info('Mouse left.');
+      this.floatSeen = false;
+    },
+    updateFloatXY(event) {
+      this.floatPosition.left = `${(event.pageX - 250)}px`;
+      this.floatPosition.top = `${event.pageY}px`;
     },
     getArticleById(id) {
       return _(this.articles).find(art => String(art.id) === String(id));

--- a/src/components/RoadmapCardTable.vue
+++ b/src/components/RoadmapCardTable.vue
@@ -46,7 +46,7 @@
              :src="data[floatDataIndex].thumbnail"
              :style="floatImageSize"
         >
-        <img v-else src="../assets/RoadmapDefault.png" :style="floatImageSize">
+        <!--img v-else src="../assets/RoadmapDefault.png" :style="floatImageSize"-->
       </div>
     <Row v-for="r in rows" v-bind:key="r" type="flex" justify="center" :gutter="20">
       <i-col v-for="c in cols" v-bind:key="c" span="6" align="center" >
@@ -284,7 +284,7 @@ export default {
     };
   },
   mounted() {
-    this.viewStyle = store.state.roadMapTable === undefined ? 'card' : store.state.roadMapTable;
+    this.viewStyle = store.state.roadMapTable !== 'table' ? 'card' : store.state.roadMapTable;
     this.initialViewStyle = this.viewStyle;
     reqSingle('/api/road_maps/', 'GET')
       .then((res) => {
@@ -491,7 +491,7 @@ export default {
     },
     updateFloatXY(event) {
       this.floatPosition.left = `${(event.pageX - 250)}px`;
-      this.floatPosition.top = `${event.pageY}px`;
+      this.floatPosition.top = `${event.pageY + 20}px`;
     },
     getArticleById(id) {
       return _(this.articles).find(art => String(art.id) === String(id));

--- a/src/components/RoadmapCardTable.vue
+++ b/src/components/RoadmapCardTable.vue
@@ -11,8 +11,8 @@
         <i-switch
           @on-change="onChangeViewStyle"
           size="large">
-          <span slot="open">Card</span>
-          <span slot="close">Table</span>
+          <span :slot="this.initialViewStyle === 'card' ? 'close' : 'open' ">Card</span>
+          <span :slot="this.initialViewStyle === 'table' ? 'close' : 'open'">Table</span>
         </i-switch>
       </div>
     </div>
@@ -116,6 +116,8 @@ import {
   delRoadmap, postRoadmapShareLink,
   createTag, updateRoadmapTag,
 } from '../apis/RoadmapEditorApis';
+import store from '../vuex/index';
+
 
 export default {
   name: 'RoadmapCardTable',
@@ -130,6 +132,7 @@ export default {
       oriTags: [],
       cols: 3,
       viewStyle: 'card',
+      initialViewStyle: undefined,
       filtArticle: -1,
       // data: [],
       rawroadmaps: [],
@@ -263,6 +266,8 @@ export default {
     };
   },
   mounted() {
+    this.viewStyle = store.state.roadMapTable === undefined ? 'card' : store.state.roadMapTable;
+    this.initialViewStyle = this.viewStyle;
     reqSingle('/api/road_maps/', 'GET')
       .then((res) => {
         // window.console.log('roadmap card', res);
@@ -455,6 +460,7 @@ export default {
       } else {
         this.viewStyle = 'card';
       }
+      store.commit('pushRoadMapTable', this.viewStyle);
     },
     mouseOnThumbnail() {
       window.console.info('Mouse enter.');

--- a/src/vuex/index.js
+++ b/src/vuex/index.js
@@ -9,6 +9,7 @@ const state = {
   example: 'vuex is backing up',
   txtArr: ['hdlnb', 'hdlswlp'],
   authToken: cookie.get('authToken'),
+  roadMapTable: cookie.get('roadMapTable'),
 };
 
 const getters = {
@@ -31,6 +32,11 @@ const mutations = {
   pushAuthToken(state, authToken) {
     state.authToken = authToken;
     cookie.set('authToken', authToken);
+  },
+  // eslint-disable-next-line no-shadow
+  pushRoadMapTable(state, style) {
+    state.roadMapTable = style;
+    cookie.set('roadMapTable', style);
   },
 };
 


### PR DESCRIPTION
1. 基于vuex缓存路书管理界面的用户偏好，记忆最后一次的状态：表格/卡片。

2. 基于mouseEnter, mouseLeave事件实现了基础的路书放大预览功能，通过移动至卡片的右上角即可显示进一步放大路书内容。

close #214 
close #188 